### PR TITLE
feat: add ability to specify unit type for data loader

### DIFF
--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -2,6 +2,7 @@ import pytest
 
 import numpy as np
 import pickle
+from astropy import units as un
 from astropy.io.misc import yaml
 
 from py21cmsense.yaml import LoadError
@@ -46,3 +47,15 @@ def test_npz_loader(tmpdirec):
     for k, v in d.items():
         assert k in obj
         assert np.allclose(v, obj[k])
+
+
+def test_txt_loader_with_unit(tmpdirec):
+    txt = tmpdirec / "test-txt.txt"
+
+    obj = np.linspace(0, 1, 10)
+
+    np.savetxt(txt, obj)
+
+    d = yaml.load(f"!txt {txt} | m")
+    assert d.unit == un.m
+    assert np.allclose(d, obj * un.m)


### PR DESCRIPTION
Adds the ability to specify units when loading data from file (especially useful for antenna positions). For example, if one has a text file for antenna positions, when writing the antpos entry to a YAML:

```
antpos: !txt datafile.txt | m
```

The appended "| m" is optional.