### PR TITLE
ci: do releases via the GH interface

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.AUTO_MERGE }}

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,27 @@
+name: Check Distribution Build
+
+on: push
+
+jobs:
+  check-build:
+    name: Twine Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Build Tools
+        run: pip install build twine
+
+      - name: Build a binary wheel
+        run: |
+          python -m build .
+
+      - name: Check Distribution
+        run: |
+          twine check dist/*

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,8 @@ jobs:
     env:
       ENV_NAME: publish
       PYTHON: "3.10"
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@main
         with:
@@ -30,6 +32,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,8 @@
 name: Publish Python distributions to PyPI
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   build-n-publish:
@@ -11,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV_NAME: publish
-      PYTHON: 3.8
+      PYTHON: "3.10"
     steps:
       - uses: actions/checkout@main
         with:
@@ -30,8 +29,7 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,6 +1,8 @@
 name: Update Draft Release
 
-on: push
+on:
+  push:
+    branches: main
 
 jobs:
   draft-release:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,21 @@
+name: Update Draft Release
+
+on: push
+
+jobs:
+  draft-release:
+    name: Update Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v5.25.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds some CI yaml files to enable releasing via the Github Release page all in one go.

It adds:

1. A release-draft yaml to update the Release draft with details from any merged PRs (I think this also updates the detected tag based on commit messages to comply with semantic versioning)
2. A check-build to check if the package builds and tests fine when NOT releasing
3. AN auto-merge-deps yaml that automatically merges dependabot PRs if they pass.
4. A labeler yaml that updates the labels in our repo

Fixes #78 