### PR TITLE
Fix 1d bin

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@master
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "pyyaml",
   "astropy>=5",
   "methodtools",
-  "pyuvdata",
+  "pyuvdata>=3.0.0",
   "cached_property",
   "rich",
   "attrs",

--- a/src/py21cmsense/_utils.py
+++ b/src/py21cmsense/_utils.py
@@ -85,9 +85,9 @@ def phase_past_zenith(
         lsts = np.array([lsts])
 
     if use_apparent:
-        app_ra, app_dec = uvutils.calc_app_coords(
-            zenith_coord.ra.to_value("rad"),
-            zenith_coord.dec.to_value("rad"),
+        app_ra, app_dec = uvutils.phasing.calc_app_coords(
+            lon_coord = zenith_coord.ra.to_value("rad"),
+            lat_coord = zenith_coord.dec.to_value("rad"),
             time_array=obstimes.utc.jd,
             telescope_loc=telescope_location,
         )
@@ -103,7 +103,7 @@ def phase_past_zenith(
     _lsts = np.tile(lsts, len(bls_enu))
     uvws = np.repeat(bls_enu, len(lsts), axis=0)
 
-    out = uvutils.calc_uvw(
+    out = uvutils.phasing.calc_uvw(
         app_ra=app_ra,
         app_dec=app_dec,
         lst_array=_lsts,

--- a/src/py21cmsense/observatory.py
+++ b/src/py21cmsense/observatory.py
@@ -148,7 +148,7 @@ class Observatory:
         return cls(
             antpos=uvdata.telescope.antenna_positions,
             beam=beam,
-            latitude=uvdata.telescope.location[0],
+            latitude=uvdata.telescope.location.lat,
             **kwargs,
         )
 

--- a/src/py21cmsense/observatory.py
+++ b/src/py21cmsense/observatory.py
@@ -148,7 +148,7 @@ class Observatory:
         return cls(
             antpos=uvdata.telescope.antenna_positions,
             beam=beam,
-            latitude=uvdata.telescope_location_lat_lon_alt[0],
+            latitude=uvdata.telescope.location[0],
             **kwargs,
         )
 

--- a/src/py21cmsense/observatory.py
+++ b/src/py21cmsense/observatory.py
@@ -146,7 +146,7 @@ class Observatory:
     def from_uvdata(cls, uvdata, beam: beam.PrimaryBeam, **kwargs) -> Observatory:
         """Instantiate an Observatory from a :class:`pyuvdata.UVData` object."""
         return cls(
-            antpos=uvdata.antenna_positions,
+            antpos=uvdata.telescope.antenna_positions,
             beam=beam,
             latitude=uvdata.telescope_location_lat_lon_alt[0],
             **kwargs,

--- a/src/py21cmsense/sensitivity.py
+++ b/src/py21cmsense/sensitivity.py
@@ -476,9 +476,9 @@ class PowerSpectrum(Sensitivity):
         self, sense: dict[tp.Wavenumber, tp.Delta], k1d: tp.Wavenumber | None = None
     ) -> tp.Delta:
         """Bin 2D sensitivity down to 1D."""
-        sense1d_inv = np.zeros(len(self.k1d)) / un.mK**4
         if k1d is None:
             k1d = self.k1d
+        sense1d_inv = np.zeros(len(self.k1d)) / un.mK**4
 
         for k_perp in tqdm.tqdm(
             sense.keys(),

--- a/src/py21cmsense/sensitivity.py
+++ b/src/py21cmsense/sensitivity.py
@@ -478,7 +478,7 @@ class PowerSpectrum(Sensitivity):
         """Bin 2D sensitivity down to 1D."""
         if k1d is None:
             k1d = self.k1d
-        sense1d_inv = np.zeros(len(self.k1d)) / un.mK**4
+        sense1d_inv = np.zeros(len(k1d)) / un.mK**4
 
         for k_perp in tqdm.tqdm(
             sense.keys(),

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -126,7 +126,7 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope.location = EarthLocation.from_geodetic(0,0)
+    uv.telescope.location = EarthLocation.from_geodetic(0, 0)
 
     a = Observatory.from_uvdata(uvdata=uv, beam=bm)
     assert np.all(a.antpos == uv.telescope.antenna_positions)

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -126,9 +126,7 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope.location = [
-        x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()
-    ]
+    uv.telescope.location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
 
     a = Observatory.from_uvdata(uvdata=uv, beam=bm)
     assert np.all(a.antpos == uv.telescope.antenna_positions)

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -122,9 +122,15 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
-    uv.telescope.antenna_positions = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
-    uv.telescope.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
+    uv.telescope.telescope_location = [
+        x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()
+    ]
+    uv.telescope.antenna_positions = (
+        np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
+    )
+    uv.telescope.telescope_location = [
+        x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()
+    ]
 
     a = Observatory.from_uvdata(uvdata=uv, beam=bm)
     assert np.all(a.antpos == uv.telescope.antenna_positions)

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -122,7 +122,7 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
+    uv.telescope.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
     uv.telescope.antenna_positions = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     uv.telescope.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
 

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -126,7 +126,7 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope.location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
+    uv.telescope.location = EarthLocation.from_geodetic(0,0)
 
     a = Observatory.from_uvdata(uvdata=uv, beam=bm)
     assert np.all(a.antpos == uv.telescope.antenna_positions)

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -122,7 +122,7 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope.telescope_location = [
+    uv.telescope.location = [
         x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()
     ]
     uv.telescope.antenna_positions = (

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -120,7 +120,7 @@ def test_min_max_antpos(bm):
 def test_from_uvdata(bm):
     uv = pyuvdata.UVData()
     uv.telescope.antenna_positions = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
-    uv.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
+    uv.telescope.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
 
     a = Observatory.from_uvdata(uvdata=uv, beam=bm)
     assert np.all(a.antpos == uv.telescope.antenna_positions)

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -119,11 +119,11 @@ def test_min_max_antpos(bm):
 
 def test_from_uvdata(bm):
     uv = pyuvdata.UVData()
-    uv.antenna_positions = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
+    uv.telescope.antenna_positions = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     uv.telescope_location = [x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()]
 
     a = Observatory.from_uvdata(uvdata=uv, beam=bm)
-    assert np.all(a.antpos == uv.antenna_positions)
+    assert np.all(a.antpos == uv.telescope.antenna_positions)
 
 
 def test_different_antpos_loaders(tmp_path: Path):

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -128,7 +128,7 @@ def test_from_uvdata(bm):
     uv.telescope.antenna_positions = (
         np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [40, 0, 40]]) * units.m
     )
-    uv.telescope.telescope_location = [
+    uv.telescope.location = [
         x.value for x in EarthLocation.from_geodetic(0, 0).to_geocentric()
     ]
 

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -63,7 +63,7 @@ def test_sensitivity_1d_binned(observation):
     assert np.all(ps.calculate_sensitivity_1d() == ps.calculate_sensitivity_1d_binned(ps.k1d))
     kbins = np.linspace(0.1, 0.5, 10) * littleh / units.Mpc
     sense1d_sample = ps.calculate_sensitivity_1d_binned(k=kbins)
-    assert sense1d_sample.shape == len(kbins)
+    assert len(sense1d_sample) == len(kbins)
 
 
 def test_plots(observation):

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -63,7 +63,7 @@ def test_sensitivity_1d_binned(observation):
     assert np.all(ps.calculate_sensitivity_1d() == ps.calculate_sensitivity_1d_binned(ps.k1d))
     kbins = np.linspace(0.1, 0.5, 10) * littleh / units.Mpc
     sense1d_sample = ps.calculate_sensitivity_1d_binned(k=kbins)
-    assert sense1d_sample.shape == len(kbins) - 1
+    assert sense1d_sample.shape == len(kbins)
 
 
 def test_plots(observation):

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -62,7 +62,7 @@ def test_sensitivity_1d_binned(observation):
     ps = PowerSpectrum(observation=observation)
     assert np.all(ps.calculate_sensitivity_1d() == ps.calculate_sensitivity_1d_binned(ps.k1d))
     kbins = np.linspace(0.1, 0.5, 10) * littleh / units.Mpc
-    sense1d_sample = ps.calculate_sensitivity_1d_binned(k=kbins/h*cu.littleh/un.Mpc)
+    sense1d_sample = ps.calculate_sensitivity_1d_binned(k=kbins)
     assert sense1d_sample.shape == len(kbins) - 1
 
 

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -61,6 +61,9 @@ def test_sensitivity_2d_grid(observation, caplog):
 def test_sensitivity_1d_binned(observation):
     ps = PowerSpectrum(observation=observation)
     assert np.all(ps.calculate_sensitivity_1d() == ps.calculate_sensitivity_1d_binned(ps.k1d))
+    kbins = np.linspace(0.1, 0.5, 10) * littleh / units.Mpc
+    sense1d_sample = ps.calculate_sensitivity_1d_binned(k=kbins/h*cu.littleh/un.Mpc)
+    assert sense1d_sample.shape == len(kbins) - 1
 
 
 def test_plots(observation):

--- a/tests/test_uvw.py
+++ b/tests/test_uvw.py
@@ -121,7 +121,7 @@ def test_calc_app_coords(lat, time_past_zenith):
     ra = zenith_coord.ra.to_value("rad")
     dec = zenith_coord.dec.to_value("rad")
     app_ra, app_dec = uvutils.phasing.calc_app_coords(
-        lon_coord = ra, lat_coord = dec, time_array=obstime.utc.jd, telescope_loc=telescope_location
+        lon_coord=ra, lat_coord=dec, time_array=obstime.utc.jd, telescope_loc=telescope_location
     )
 
     assert np.isclose(app_ra, ra, atol=0.02)  # give it 1 degree wiggle room.

--- a/tests/test_uvw.py
+++ b/tests/test_uvw.py
@@ -120,8 +120,8 @@ def test_calc_app_coords(lat, time_past_zenith):
 
     ra = zenith_coord.ra.to_value("rad")
     dec = zenith_coord.dec.to_value("rad")
-    app_ra, app_dec = uvutils.calc_app_coords(
-        ra, dec, time_array=obstime.utc.jd, telescope_loc=telescope_location
+    app_ra, app_dec = uvutils.phasing.calc_app_coords(
+        lon_coord = ra, lat_coord = dec, time_array=obstime.utc.jd, telescope_loc=telescope_location
     )
 
     assert np.isclose(app_ra, ra, atol=0.02)  # give it 1 degree wiggle room.


### PR DESCRIPTION
Fix  for bug in `calculate_sensitivity_1d_binned`:

```
ska = Observatory.from_profile("SKA-LOW1-core", frequency=band * un.MHz)
obs = p21sense.Observation(
    observatory=ska,
    #TRACK: Need this for track scan option
    # Tracked scan observation duration.
    track=4.*un.hour, 
    #If simulating a tracked scan, `time_per_day` should be a multiple of the length
    #    of the track (i.e. for two three-hour tracks per day, `hours_per_day` should be 6).
    time_per_day=4.*un.hour,
    n_days=180.,
)
sense = PowerSpectrum(observation=obs)
k_bins = np.logspace(np.log10(0.1),np.log10(1.1),20) # this is in Mpc^{-1}
sense1d_sample = sense.calculate_sensitivity_1d_binned(k=k_bins/h*cu.littleh/un.Mpc, 
                                              thermal=False, 
                                              sample=True)
print(len(sense1d_sample), len(k_bins))
```

output is: 81, 20. Expected output: 20, 20.